### PR TITLE
Readme: Removed dump from example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,6 @@ Now when we give it a string, it will return array of tokens.
 
 ```php
 $tokens = $tokenizer->tokenize("say \n123");
-dump($tokens);
 ```
 
 The resulting array of tokens would look like this.


### PR DESCRIPTION
It is not used. Text continues explaining contents of that variable not result of dump.
