### PR TITLE
Alternatives for reading tokenize output in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,8 @@ echo $firstToken[Tokenizer::TYPE]; // 308, which is the value of T_STRING
 // or shorter
 list($value, $offset, $type) = $tokens[0];
 
-foreach ($tokens as list($value, $offset, $type)) { // since PHP 5.5 you can use list in foreach
+// since PHP 5.5 you can do even this
+foreach ($tokens as list($value, $offset, $type)) {
     // ...
 }
 ```


### PR DESCRIPTION
I realized that using constants might be bad for code flow if someone uses tokenize directly.

So I added list and foreach list to remind people that there is simpler and clearer way.

This is more like suggestion then prepared pull.
