### PR TITLE
Stream: add getTokens()

### DIFF
--- a/src/Tokenizer/Stream.php
+++ b/src/Tokenizer/Stream.php
@@ -35,6 +35,15 @@ class Stream
 
 
 	/**
+	 * @return Token[]
+	 */
+	public function getTokens(): array
+	{
+		return $this->tokens;
+	}
+
+
+	/**
 	 * Returns current token.
 	 */
 	public function currentToken(): ?Token


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no

Restores the ability to get access to the tokens array which was removed in https://github.com/nette/tokenizer/commit/ac1d424217e099cd6ee2e6c7e4b95d3841bc4183